### PR TITLE
feat: KCL Kubernetes manifests

### DIFF
--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -1,0 +1,21 @@
+"""
+ConfigMap for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+configMap = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: "{}-config".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        LOG_LEVEL: "info"
+        **config.extraEnvVars
+    }
+}

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -1,0 +1,173 @@
+"""
+Deployment for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+deployment = {
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        replicas: config.replicas
+        selector: {
+            matchLabels: labels.selectorLabels
+        }
+        strategy: {
+            type: "RollingUpdate"
+            rollingUpdate: {
+                maxSurge: 1
+                maxUnavailable: 0
+            }
+        }
+        template: {
+            metadata: {
+                labels: labels.commonLabels
+            }
+            spec: {
+                serviceAccountName: config.name
+                containers: [
+                    {
+                        name: config.name
+                        image: config.image
+                        imagePullPolicy: config.imagePullPolicy
+                        ports: [
+                            {
+                                name: "http"
+                                containerPort: config.containerPort
+                                protocol: "TCP"
+                            }
+                        ]
+                        env: [
+                            {
+                                name: "PORT"
+                                value: str(config.containerPort)
+                            }
+                            {
+                                name: "AUTH_TOKEN"
+                                valueFrom: {
+                                    secretKeyRef: {
+                                        name: "{}-token".format(config.name)
+                                        key: "auth-token"
+                                    }
+                                }
+                            }
+                            {
+                                name: "REDIS_ADDR"
+                                value: config.redisAddr
+                            }
+                            {
+                                name: "REDIS_PORT"
+                                value: str(config.redisPort)
+                            }
+                            {
+                                name: "REDIS_PASSWORD"
+                                valueFrom: {
+                                    secretKeyRef: {
+                                        name: "{}-redis".format(config.name)
+                                        key: "password"
+                                    }
+                                }
+                            }
+                            {
+                                name: "REDISEARCH_INDEX"
+                                value: config.redisearchIndex
+                            }
+                            {
+                                name: "SCOUT_INTERVAL"
+                                value: config.scoutInterval
+                            }
+                        ]
+                        envFrom: [
+                            {
+                                configMapRef: {
+                                    name: "{}-config".format(config.name)
+                                }
+                            }
+                        ]
+                        resources: {
+                            requests: {
+                                cpu: config.cpuRequest
+                                memory: config.memoryRequest
+                            }
+                            limits: {
+                                cpu: config.cpuLimit
+                                memory: config.memoryLimit
+                            }
+                        }
+                        livenessProbe: {
+                            httpGet: {
+                                path: "/health"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 10
+                            periodSeconds: 10
+                            timeoutSeconds: 5
+                            failureThreshold: 3
+                        }
+                        readinessProbe: {
+                            httpGet: {
+                                path: "/health"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 5
+                            periodSeconds: 5
+                            timeoutSeconds: 3
+                            failureThreshold: 3
+                        }
+                        securityContext: {
+                            readOnlyRootFilesystem: True
+                            runAsNonRoot: True
+                            allowPrivilegeEscalation: False
+                            capabilities: {
+                                drop: ["ALL"]
+                            }
+                        }
+                        volumeMounts: [
+                            {
+                                name: "tmp"
+                                mountPath: "/tmp"
+                            }
+                        ]
+                    }
+                ]
+                securityContext: {
+                    runAsNonRoot: True
+                    runAsUser: 65532
+                    runAsGroup: 65532
+                    fsGroup: 65532
+                    seccompProfile: {
+                        type: "RuntimeDefault"
+                    }
+                }
+                volumes: [
+                    {
+                        name: "tmp"
+                        emptyDir: {}
+                    }
+                ]
+                affinity: {
+                    podAntiAffinity: {
+                        preferredDuringSchedulingIgnoredDuringExecution: [
+                            {
+                                weight: 100
+                                podAffinityTerm: {
+                                    labelSelector: {
+                                        matchLabels: labels.selectorLabels
+                                    }
+                                    topologyKey: "kubernetes.io/hostname"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -1,0 +1,53 @@
+"""
+HTTPRoute (Gateway API) for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+_hostname = config.httpRouteHostname or config.ingressHost
+
+httproute = {
+    apiVersion: "gateway.networking.k8s.io/v1"
+    kind: "HTTPRoute"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations or config.httpRouteAnnotations:
+            annotations: {
+                **config.annotations
+                **config.httpRouteAnnotations
+            }
+    }
+    spec: {
+        parentRefs: [
+            {
+                name: config.httpRouteParentRefName
+                if config.httpRouteParentRefNamespace:
+                    namespace: config.httpRouteParentRefNamespace
+            }
+        ]
+        if _hostname:
+            hostnames: [_hostname]
+        rules: [
+            {
+                matches: [
+                    {
+                        path: {
+                            type: "PathPrefix"
+                            value: "/"
+                        }
+                    }
+                ]
+                backendRefs: [
+                    {
+                        name: config.name
+                        port: config.servicePort
+                    }
+                ]
+            }
+        ]
+    }
+} if config.httpRouteEnabled else None

--- a/kcl/ingress.k
+++ b/kcl/ingress.k
@@ -1,0 +1,55 @@
+"""
+Ingress for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+ingress = {
+    apiVersion: "networking.k8s.io/v1"
+    kind: "Ingress"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        annotations: {
+            "nginx.ingress.kubernetes.io/ssl-redirect": "true" if config.ingressTlsEnabled else "false"
+            "nginx.ingress.kubernetes.io/proxy-body-size": "10m"
+            "nginx.ingress.kubernetes.io/limit-rps": "100"
+            **config.annotations
+            **config.ingressAnnotations
+        }
+    }
+    spec: {
+        ingressClassName: config.ingressClassName
+        if config.ingressTlsEnabled:
+            tls: [
+                {
+                    hosts: [config.ingressHost]
+                    secretName: config.ingressTlsSecretName
+                }
+            ]
+        rules: [
+            {
+                host: config.ingressHost
+                http: {
+                    paths: [
+                        {
+                            path: "/"
+                            pathType: "Prefix"
+                            backend: {
+                                service: {
+                                    name: config.name
+                                    port: {
+                                        number: config.servicePort
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+} if config.ingressEnabled else None

--- a/kcl/kcl.mod
+++ b/kcl/kcl.mod
@@ -1,0 +1,12 @@
+[package]
+name = "deploy-homerun2-scout"
+version = "0.1.0"
+description = "KCL module for deploying homerun2-scout on Kubernetes"
+
+[dependencies]
+k8s = "1.31"
+
+[profile]
+entries = [
+    "main.k"
+]

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -1,0 +1,83 @@
+"""
+Common labels for homerun2-scout resources
+"""
+
+import schema
+
+# Get command-line options
+_image = option("config.image")
+_namespace = option("config.namespace")
+_ingressEnabled = option("config.ingressEnabled")
+_ingressHost = option("config.ingressHost")
+_ingressTlsEnabled = option("config.ingressTlsEnabled")
+_ingressTlsSecretName = option("config.ingressTlsSecretName")
+_ingressAnnotations = option("config.ingressAnnotations") or {}
+_httpRouteEnabled = option("config.httpRouteEnabled")
+_httpRouteParentRefName = option("config.httpRouteParentRefName")
+_httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
+_httpRouteHostname = option("config.httpRouteHostname")
+_httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_redisAddr = option("config.redisAddr")
+_redisPort = option("config.redisPort")
+_redisearchIndex = option("config.redisearchIndex")
+_scoutInterval = option("config.scoutInterval")
+_authToken = option("config.authToken")
+_redisPassword = option("config.redisPassword")
+_extraEnvVars = option("config.extraEnvVars") or {}
+
+# Config instance with command-line overrides
+config: schema.Scout = schema.Scout {
+    if _image:
+        image = _image
+    if _namespace:
+        namespace = _namespace
+    if _ingressEnabled:
+        ingressEnabled = _ingressEnabled in [True, "True", "true"]
+    if _ingressHost:
+        ingressHost = _ingressHost
+    if _ingressTlsEnabled:
+        ingressTlsEnabled = _ingressTlsEnabled in [True, "True", "true"]
+    if _ingressTlsSecretName:
+        ingressTlsSecretName = _ingressTlsSecretName
+    if _ingressAnnotations:
+        ingressAnnotations = _ingressAnnotations
+    if _httpRouteEnabled:
+        httpRouteEnabled = _httpRouteEnabled in [True, "True", "true"]
+    if _httpRouteParentRefName:
+        httpRouteParentRefName = _httpRouteParentRefName
+    if _httpRouteParentRefNamespace:
+        httpRouteParentRefNamespace = _httpRouteParentRefNamespace
+    if _httpRouteHostname:
+        httpRouteHostname = _httpRouteHostname
+    if _httpRouteAnnotations:
+        httpRouteAnnotations = _httpRouteAnnotations
+    if _redisAddr:
+        redisAddr = _redisAddr
+    if _redisPort:
+        redisPort = _redisPort
+    if _redisearchIndex:
+        redisearchIndex = _redisearchIndex
+    if _scoutInterval:
+        scoutInterval = _scoutInterval
+    if _authToken:
+        authToken = _authToken
+    if _redisPassword:
+        redisPassword = _redisPassword
+    if _extraEnvVars:
+        extraEnvVars = _extraEnvVars
+}
+
+# Common labels applied to all resources
+commonLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+    "app.kubernetes.io/component": "analytics"
+    "app.kubernetes.io/part-of": "homerun2"
+    **config.labels
+}
+
+# Selector labels for pods
+selectorLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+}

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -1,0 +1,28 @@
+"""
+Main entry point for homerun2-scout Kubernetes deployment
+Imports all resources and exports manifests
+"""
+
+import namespace
+import serviceaccount
+import configmap
+import secret
+import deploy
+import service
+import ingress
+import httproute
+
+# Export all manifests (filter out None values)
+manifests = [
+    m for m in [
+        namespace.namespace
+        serviceaccount.serviceAccount
+        configmap.configMap
+        secret.secretToken
+        secret.secretRedis
+        deploy.deployment
+        service.service
+        ingress.ingress
+        httproute.httproute
+    ] if m
+]

--- a/kcl/namespace.k
+++ b/kcl/namespace.k
@@ -1,0 +1,16 @@
+"""
+Namespace for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+namespace = {
+    apiVersion: "v1"
+    kind: "Namespace"
+    metadata: {
+        name: config.namespace
+        labels: labels.commonLabels
+    }
+}

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -1,0 +1,67 @@
+"""
+Schema definition for homerun2-scout deployment configuration
+"""
+
+schema Scout:
+    """Configuration for homerun2-scout Kubernetes deployment"""
+
+    # Metadata
+    name: str = "homerun2-scout"
+    namespace: str = "homerun2"
+
+    # Image
+    image: str = "ghcr.io/stuttgart-things/homerun2-scout:latest"
+    imagePullPolicy: str = "IfNotPresent"
+
+    # Replicas and resources
+    replicas: int = 1
+    cpuRequest: str = "100m"
+    cpuLimit: str = "500m"
+    memoryRequest: str = "128Mi"
+    memoryLimit: str = "512Mi"
+
+    # Service
+    serviceType: str = "ClusterIP"
+    servicePort: int = 80
+    containerPort: int = 8080
+
+    # Ingress
+    ingressEnabled: bool = False
+    ingressClassName: str = "nginx"
+    ingressHost: str = "homerun2-scout.example.com"
+    ingressTlsEnabled: bool = False
+    ingressTlsSecretName: str = "homerun2-scout-tls"
+    ingressAnnotations: {str:str} = {}
+
+    # HTTPRoute (Gateway API)
+    httpRouteEnabled: bool = False
+    httpRouteParentRefName: str = ""
+    httpRouteParentRefNamespace: str = ""
+    httpRouteHostname: str = ""
+    httpRouteAnnotations: {str:str} = {}
+
+    # Redis / RediSearch
+    redisAddr: str = "redis-stack.homerun2.svc.cluster.local"
+    redisPort: int | str = "6379"
+    redisearchIndex: str = "messages"
+
+    # Scout-specific
+    scoutInterval: str = "60s"
+
+    # Secrets
+    authToken: str = ""
+    redisPassword: str = ""
+
+    # Extra environment variables
+    extraEnvVars: {str:str} = {}
+
+    # Labels and annotations
+    labels: {str:str} = {}
+    annotations: {str:str} = {}
+
+    check:
+        replicas >= 0, "replicas must be >= 0"
+        servicePort >= 1 and servicePort <= 65535, "servicePort must be valid"
+        containerPort >= 1 and containerPort <= 65535, "containerPort must be valid"
+        name != "", "name must not be empty"
+        namespace != "", "namespace must not be empty"

--- a/kcl/secret.k
+++ b/kcl/secret.k
@@ -1,0 +1,38 @@
+"""
+Secrets for homerun2-scout
+"""
+
+import base64
+import labels
+
+config = labels.config
+
+# Secret - Auth Token
+secretToken = {
+    apiVersion: "v1"
+    kind: "Secret"
+    metadata: {
+        name: "{}-token".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    type: "Opaque"
+    data: {
+        "auth-token": base64.encode(config.authToken)
+    }
+} if config.authToken else None
+
+# Secret - Redis
+secretRedis = {
+    apiVersion: "v1"
+    kind: "Secret"
+    metadata: {
+        name: "{}-redis".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    type: "Opaque"
+    data: {
+        password: base64.encode(config.redisPassword)
+    }
+} if config.redisPassword else None

--- a/kcl/service.k
+++ b/kcl/service.k
@@ -1,0 +1,29 @@
+"""
+Service for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+service = {
+    apiVersion: "v1"
+    kind: "Service"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        type: config.serviceType
+        ports: [
+            {
+                name: "http"
+                port: config.servicePort
+                targetPort: "http"
+                protocol: "TCP"
+            }
+        ]
+        selector: labels.selectorLabels
+    }
+}

--- a/kcl/serviceaccount.k
+++ b/kcl/serviceaccount.k
@@ -1,0 +1,17 @@
+"""
+ServiceAccount for homerun2-scout
+"""
+
+import labels
+
+config = labels.config
+
+serviceAccount = {
+    apiVersion: "v1"
+    kind: "ServiceAccount"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+}

--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -1,0 +1,14 @@
+---
+config.image: ghcr.io/stuttgart-things/homerun2-scout:latest
+config.namespace: homerun2
+config.ingressEnabled: true
+config.ingressHost: homerun2-scout.example.com
+config.ingressTlsEnabled: true
+config.ingressAnnotations:
+  cert-manager.io/cluster-issuer: cluster-issuer-approle
+config.redisAddr: redis-stack.homerun2.svc.cluster.local
+config.redisPort: "6379"
+config.redisearchIndex: messages
+config.scoutInterval: "60s"
+config.authToken: changeme
+config.redisPassword: changeme # pragma: allowlist secret


### PR DESCRIPTION
## Summary
- Adds modular KCL manifests adapted from omni-pitcher for Kubernetes deployment
- Includes scout-specific config: `REDISEARCH_INDEX`, `SCOUT_INTERVAL` env vars
- Deployment profile for parameterized rendering in `tests/kcl-deploy-profile.yaml`

## Test plan
- [ ] `task render-manifests-quick` produces valid YAML
- [ ] Manifests include scout-specific env vars
- [ ] Ingress/HTTPRoute conditional rendering works

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)