### PR TITLE
docs: MkDocs site with API, deployment, and CI/CD pages

### DIFF
--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -1,0 +1,115 @@
+# API Usage
+
+## Health Check
+
+```bash
+curl http://localhost:8080/health
+```
+
+Response:
+
+```json
+{
+  "status": "ok",
+  "version": "1.0.0",
+  "commit": "abc123",
+  "date": "2026-03-11",
+  "uptime": "2h30m15s"
+}
+```
+
+## Analytics Summary
+
+Returns overall message counts grouped by severity.
+
+```bash
+curl http://localhost:8080/analytics/summary \
+  -H "Authorization: Bearer $AUTH_TOKEN"
+```
+
+Response:
+
+```json
+{
+  "totalMessages": 1542,
+  "severityCounts": {
+    "info": 1200,
+    "warning": 250,
+    "error": 80,
+    "critical": 12
+  },
+  "timeWindow": "60s",
+  "lastUpdated": "2026-03-11T12:00:00Z"
+}
+```
+
+## Systems
+
+Returns per-system message counts, sorted by count descending (top 20).
+
+```bash
+curl http://localhost:8080/analytics/systems \
+  -H "Authorization: Bearer $AUTH_TOKEN"
+```
+
+Response:
+
+```json
+{
+  "systems": [
+    {"system": "api-gateway", "count": 500},
+    {"system": "worker-pool", "count": 320},
+    {"system": "scheduler", "count": 180}
+  ],
+  "total": 3,
+  "lastUpdated": "2026-03-11T12:00:00Z"
+}
+```
+
+## Alerts
+
+Returns alert statistics (error + critical severity only) with top alerting systems.
+
+```bash
+curl http://localhost:8080/analytics/alerts \
+  -H "Authorization: Bearer $AUTH_TOKEN"
+```
+
+Response:
+
+```json
+{
+  "totalAlerts": 92,
+  "severityCounts": {
+    "error": 80,
+    "critical": 12
+  },
+  "topSystems": [
+    {"system": "api-gateway", "count": 45},
+    {"system": "worker-pool", "count": 30}
+  ],
+  "lastUpdated": "2026-03-11T12:00:00Z"
+}
+```
+
+## Error Responses
+
+### 401 Unauthorized
+
+Missing or invalid Bearer token:
+
+```json
+{"error": "missing authorization header"}
+```
+
+```json
+{"error": "invalid token"}
+```
+
+### 405 Method Not Allowed
+
+Wrong HTTP method (e.g., POST to a GET endpoint):
+
+```json
+{"error": "method not allowed"}
+```

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,46 @@
+# CI/CD
+
+## GitHub Actions Workflows
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| `build-test.yaml` | PR / push to main | Dagger lint + build + test |
+| `build-scan-image.yaml` | Push to main | ko build + Trivy scan |
+| `release.yaml` | After image build / manual | Semantic release + stage image + push kustomize OCI |
+| `lint-repo.yaml` | PR / push to main | Repository linting |
+| `pages.yaml` | After release / manual | Deploy MkDocs to GitHub Pages |
+
+## Dagger Functions
+
+The `dagger/` module provides:
+
+| Function | Description |
+|----------|-------------|
+| `Lint` | Go linting via golangci-lint |
+| `Build` | Build Go binary |
+| `BuildImage` | Build container image with ko |
+| `ScanImage` | Trivy vulnerability scan |
+| `BuildAndTestBinary` | Build + Redis integration test |
+
+## Taskfile
+
+Common tasks available via `task`:
+
+```bash
+task lint                  # Run golangci-lint
+task build-test-binary     # Build and test with Redis via Dagger
+task build-output-binary   # Build Go binary
+task build-scan-image-ko   # Build + scan with ko
+task render-manifests-quick # Render KCL manifests
+task trigger-release       # Trigger release workflow
+```
+
+## Release Process
+
+Releases are automated via semantic-release:
+
+1. Push to `main` triggers build + image workflow
+2. On success, release workflow runs semantic-release
+3. If releasable commits exist, a new version tag is created
+4. Container image is staged from `:main` to `:vX.Y.Z`
+5. Kustomize base is pushed as OCI artifact to GHCR

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,80 @@
+# Deployment
+
+## Kubernetes Manifests (KCL)
+
+Manifests are generated using KCL in the `kcl/` directory. The modular structure:
+
+| File               | Resource        |
+|--------------------|-----------------|
+| `schema.k`         | Config schema with validation |
+| `labels.k`         | Common labels and config instantiation |
+| `namespace.k`      | Namespace       |
+| `serviceaccount.k` | ServiceAccount  |
+| `configmap.k`      | ConfigMap       |
+| `secret.k`         | Secrets (auth token, redis password) |
+| `deploy.k`         | Deployment      |
+| `service.k`        | Service         |
+| `ingress.k`        | Ingress (optional) |
+| `httproute.k`      | HTTPRoute via Gateway API (optional) |
+| `main.k`           | Entry point     |
+
+## Render Manifests
+
+```bash
+# Using Taskfile
+task render-manifests-quick
+
+# Using KCL directly
+kcl kcl/main.k -Y tests/kcl-deploy-profile.yaml
+```
+
+## Configuration Options
+
+Override via KCL profile file or CLI options:
+
+```yaml
+config:
+  image: ghcr.io/stuttgart-things/homerun2-scout:v1.0.0
+  namespace: homerun2
+  ingressEnabled: true
+  ingressHost: scout.example.com
+  redisAddr: redis-stack.homerun2.svc.cluster.local
+  redisPort: "6379"
+  redisearchIndex: messages
+  scoutInterval: "60s"
+  authToken: my-secret-token
+  redisPassword: redis-pass
+```
+
+## Scout-Specific Environment Variables
+
+The deployment includes these scout-specific env vars in addition to the standard Redis config:
+
+| Variable            | Source    | Description                 |
+|---------------------|-----------|------------------------------|
+| `REDISEARCH_INDEX`  | deploy.k  | RediSearch index to query   |
+| `SCOUT_INTERVAL`    | deploy.k  | Aggregation polling interval |
+
+## Kustomize OCI Pipeline
+
+Releases push a kustomize base as an OCI artifact:
+
+```bash
+# Pull the base
+oras pull ghcr.io/stuttgart-things/homerun2-scout-kustomize:v1.0.0
+
+# Apply with overlays
+kubectl apply -k .
+```
+
+## Container Image
+
+Built with [ko](https://ko.build/) using a distroless base image (`cgr.dev/chainguard/static:latest`):
+
+```bash
+# Build locally
+ko build .
+
+# Build via Taskfile
+task build-scan-image-ko
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,67 @@
+# Homerun2 Scout
+
+A periodic analytics service that analyzes messages indexed in RediSearch and exposes aggregated insights via a REST API.
+
+## Overview
+
+Scout is part of the homerun2 platform. It periodically runs `FT.AGGREGATE` queries against the RediSearch index (populated by omni-pitcher's dual-write) and caches the results for fast API access.
+
+## Quick Start
+
+```bash
+# Set required environment variables
+export REDIS_ADDR=redis-stack.homerun2.svc.cluster.local
+export REDIS_PORT=6379
+export REDISEARCH_INDEX=messages
+export SCOUT_INTERVAL=60s
+export AUTH_TOKEN=your-secret-token
+
+# Run locally
+go run main.go
+```
+
+## API Endpoints
+
+| Endpoint               | Method | Auth     | Description                              |
+|------------------------|--------|----------|------------------------------------------|
+| `/health`              | GET    | No       | Health check (version, uptime)           |
+| `/analytics/summary`   | GET    | Bearer   | Severity counts, total messages          |
+| `/analytics/systems`   | GET    | Bearer   | Per-system message counts, top N         |
+| `/analytics/alerts`    | GET    | Bearer   | Alert frequency, top alerting systems    |
+
+## Authentication
+
+All `/analytics/*` endpoints require a Bearer token:
+
+```bash
+curl http://localhost:8080/analytics/summary \
+  -H "Authorization: Bearer $AUTH_TOKEN"
+```
+
+## Architecture
+
+- **Go** stdlib `net/http` — HTTP server with graceful shutdown
+- **RediSearch** — `FT.AGGREGATE` queries for analytics
+- **time.Ticker** — Periodic aggregation on configurable interval
+- **ko** — Container image builds (distroless)
+- **KCL** — Kubernetes manifest generation
+- **Dagger** — CI/CD pipeline functions
+
+## Configuration
+
+| Variable            | Default     | Description                          |
+|---------------------|-------------|--------------------------------------|
+| `REDIS_ADDR`        | `localhost` | Redis host                           |
+| `REDIS_PORT`        | `6379`      | Redis port                           |
+| `REDIS_PASSWORD`    | (empty)     | Redis password                       |
+| `REDISEARCH_INDEX`  | `messages`  | RediSearch index name                |
+| `SCOUT_INTERVAL`    | `60s`       | Aggregation interval                 |
+| `AUTH_TOKEN`        | (empty)     | Bearer token for API auth            |
+| `PORT`              | `8080`      | HTTP server port                     |
+| `LOG_FORMAT`        | `json`      | Log format (`json` or `text`)        |
+| `LOG_LEVEL`         | `info`      | Log level (`debug`, `info`, `warn`, `error`) |
+
+## Prerequisites
+
+- **omni-pitcher** must be running with RediSearch dual-write enabled (`REDIS_SEARCH_INDEX` env var set)
+- **Redis Stack** with RediSearch module loaded

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,11 @@
+site_name: Homerun2 Scout
+site_description: Periodic analytics service for RediSearch data
+
+nav:
+  - Home: index.md
+  - API Usage: api-usage.md
+  - Deployment: deployment.md
+  - CI/CD: cicd.md
+
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- Adds `mkdocs.yml` with techdocs-core plugin for Backstage integration
- Documentation pages: overview, API usage with examples, deployment guide, CI/CD reference
- Fixes Pages workflow failure (missing docs scaffolding)

## Test plan
- [ ] Pages workflow succeeds after merge
- [ ] MkDocs renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)