### PR TITLE
feat: retention/cleanup — prune old RediSearch entries by TTL

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	RedisPassword    string
 	RedisearchIndex  string
 	ScoutInterval    time.Duration
+	RetentionTTL     time.Duration
+	RetentionEnabled bool
 	AuthToken        string
 	Port             string
 	LogFormat        string
@@ -39,6 +41,16 @@ func LoadConfig() (*Config, error) {
 		return nil, fmt.Errorf("invalid SCOUT_INTERVAL %q: %w", intervalStr, err)
 	}
 	cfg.ScoutInterval = d
+
+	retentionStr := getEnv("SCOUT_RETENTION_TTL", "")
+	if retentionStr != "" {
+		ttl, err := time.ParseDuration(retentionStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid SCOUT_RETENTION_TTL %q: %w", retentionStr, err)
+		}
+		cfg.RetentionTTL = ttl
+		cfg.RetentionEnabled = true
+	}
 
 	return cfg, nil
 }

--- a/internal/retention/retention.go
+++ b/internal/retention/retention.go
@@ -1,0 +1,131 @@
+package retention
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Cleaner periodically prunes old entries from a RediSearch index based on TTL.
+type Cleaner struct {
+	client   *redis.Client
+	index    string
+	ttl      time.Duration
+	interval time.Duration
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// New creates a new retention Cleaner.
+func New(client *redis.Client, index string, ttl, interval time.Duration) *Cleaner {
+	return &Cleaner{
+		client:   client,
+		index:    index,
+		ttl:      ttl,
+		interval: interval,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start begins the periodic cleanup loop.
+func (c *Cleaner) Start(ctx context.Context) {
+	ctx, c.cancel = context.WithCancel(ctx)
+
+	go func() {
+		defer close(c.done)
+		ticker := time.NewTicker(c.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.cleanup(ctx)
+			}
+		}
+	}()
+
+	slog.Info("retention cleaner started", "ttl", c.ttl, "interval", c.interval)
+}
+
+// Stop stops the cleanup loop.
+func (c *Cleaner) Stop() {
+	if c.cancel != nil {
+		c.cancel()
+		<-c.done
+	}
+	slog.Info("retention cleaner stopped")
+}
+
+func (c *Cleaner) cleanup(ctx context.Context) {
+	cutoff := time.Now().Add(-c.ttl).Unix()
+	slog.Debug("running retention cleanup", "cutoffUnix", cutoff)
+
+	// FT.SEARCH <index> @timestamp:[-inf <cutoff>] NOCONTENT LIMIT 0 1000
+	query := fmt.Sprintf("@timestamp:[-inf %d]", cutoff)
+	args := []interface{}{
+		"FT.SEARCH", c.index, query,
+		"NOCONTENT",
+		"LIMIT", "0", "1000",
+	}
+
+	result, err := c.client.Do(ctx, args...).Result()
+	if err != nil {
+		slog.Warn("retention cleanup search failed", "error", err)
+		return
+	}
+
+	keys := parseSearchKeys(result)
+	if len(keys) == 0 {
+		slog.Debug("retention cleanup: no expired entries")
+		return
+	}
+
+	// Delete expired keys
+	deleted := 0
+	for _, key := range keys {
+		if err := c.client.Del(ctx, key).Err(); err != nil {
+			slog.Warn("retention cleanup: failed to delete key", "key", key, "error", err)
+			continue
+		}
+		deleted++
+	}
+
+	slog.Info("retention cleanup complete", "found", len(keys), "deleted", deleted)
+}
+
+// parseSearchKeys extracts document keys from FT.SEARCH NOCONTENT response.
+// FT.SEARCH NOCONTENT returns: [totalResults, key1, key2, ...]
+func parseSearchKeys(result interface{}) []string {
+	arr, ok := result.([]interface{})
+	if !ok || len(arr) < 2 {
+		return nil
+	}
+
+	// First element is total count
+	total, ok := arr[0].(int64)
+	if !ok || total == 0 {
+		// Try string conversion
+		if s, ok := arr[0].(string); ok {
+			t, err := strconv.ParseInt(s, 10, 64)
+			if err != nil || t == 0 {
+				return nil
+			}
+		} else {
+			return nil
+		}
+	}
+
+	var keys []string
+	for i := 1; i < len(arr); i++ {
+		if key, ok := arr[i].(string); ok {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}

--- a/internal/retention/retention_test.go
+++ b/internal/retention/retention_test.go
@@ -1,0 +1,47 @@
+package retention
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseSearchKeys(t *testing.T) {
+	// FT.SEARCH NOCONTENT response: [3, "key1", "key2", "key3"]
+	result := []interface{}{int64(3), "doc:1", "doc:2", "doc:3"}
+
+	keys := parseSearchKeys(result)
+	if len(keys) != 3 {
+		t.Fatalf("expected 3 keys, got %d", len(keys))
+	}
+	if keys[0] != "doc:1" {
+		t.Errorf("keys[0] = %q, want %q", keys[0], "doc:1")
+	}
+}
+
+func TestParseSearchKeysEmpty(t *testing.T) {
+	result := []interface{}{int64(0)}
+	keys := parseSearchKeys(result)
+	if len(keys) != 0 {
+		t.Fatalf("expected 0 keys, got %d", len(keys))
+	}
+}
+
+func TestParseSearchKeysNil(t *testing.T) {
+	keys := parseSearchKeys(nil)
+	if keys != nil {
+		t.Fatalf("expected nil, got %v", keys)
+	}
+}
+
+func TestNewCleaner(t *testing.T) {
+	c := New(nil, "test-index", 168*time.Hour, time.Hour)
+	if c.index != "test-index" {
+		t.Errorf("index = %q, want %q", c.index, "test-index")
+	}
+	if c.ttl != 168*time.Hour {
+		t.Errorf("ttl = %v, want %v", c.ttl, 168*time.Hour)
+	}
+	if c.interval != time.Hour {
+		t.Errorf("interval = %v, want %v", c.interval, time.Hour)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stuttgart-things/homerun2-scout/internal/config"
 	"github.com/stuttgart-things/homerun2-scout/internal/handlers"
 	"github.com/stuttgart-things/homerun2-scout/internal/middleware"
+	"github.com/stuttgart-things/homerun2-scout/internal/retention"
 )
 
 var (
@@ -57,6 +58,13 @@ func main() {
 	agg := aggregator.New(rdb, cfg.RedisearchIndex, cfg.ScoutInterval)
 	agg.Start(ctx)
 
+	// Start retention cleaner (if enabled)
+	var cleaner *retention.Cleaner
+	if cfg.RetentionEnabled {
+		cleaner = retention.New(rdb, cfg.RedisearchIndex, cfg.RetentionTTL, cfg.ScoutInterval)
+		cleaner.Start(ctx)
+	}
+
 	// Setup routes
 	mux := http.NewServeMux()
 
@@ -94,6 +102,11 @@ func main() {
 	<-quit
 
 	slog.Info("shutting down...")
+
+	// Stop retention cleaner
+	if cleaner != nil {
+		cleaner.Stop()
+	}
 
 	// Stop aggregator
 	agg.Stop()


### PR DESCRIPTION
## Summary
- Adds `internal/retention/` package with periodic cleanup of expired RediSearch entries
- Configurable via `SCOUT_RETENTION_TTL` env var (e.g., `168h` for 7 days)
- Disabled by default; set TTL to enable
- Uses `FT.SEARCH` with timestamp filter + `DEL` for cleanup
- Cleanup stats logged each cycle

## Test plan
- [ ] `go test ./...` passes
- [ ] Cleaner starts only when `SCOUT_RETENTION_TTL` is set
- [ ] Cleanup logs found/deleted counts

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)