### PR TITLE
feat: threshold alerting — detect anomalies and pitch meta-alerts

### DIFF
--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -11,6 +11,9 @@ import (
 	"github.com/stuttgart-things/homerun2-scout/internal/models"
 )
 
+// CycleCallback is called after each aggregation cycle with the latest results.
+type CycleCallback func(ctx context.Context, summary *models.Summary, alerts *models.AlertStats)
+
 // Aggregator periodically runs FT.AGGREGATE queries and caches results.
 type Aggregator struct {
 	client   *redis.Client
@@ -22,8 +25,9 @@ type Aggregator struct {
 	systems *models.SystemStats
 	alerts  *models.AlertStats
 
-	cancel context.CancelFunc
-	done   chan struct{}
+	onCycle CycleCallback
+	cancel  context.CancelFunc
+	done    chan struct{}
 }
 
 // New creates a new Aggregator.
@@ -34,6 +38,11 @@ func New(client *redis.Client, index string, interval time.Duration) *Aggregator
 		interval: interval,
 		done:     make(chan struct{}),
 	}
+}
+
+// SetOnCycleCallback sets a callback invoked after each aggregation cycle.
+func (a *Aggregator) SetOnCycleCallback(cb CycleCallback) {
+	a.onCycle = cb
 }
 
 // Start begins the periodic aggregation loop.
@@ -134,6 +143,11 @@ func (a *Aggregator) runOnce(ctx context.Context) {
 	metrics.SystemsTotal.Set(float64(systems.Total))
 	for sev, count := range alerts.SeverityCounts {
 		metrics.AlertsTotal.WithLabelValues(sev).Set(float64(count))
+	}
+
+	// Invoke callback if set
+	if a.onCycle != nil {
+		a.onCycle(ctx, summary, alerts)
 	}
 
 	slog.Info("aggregation cycle complete",

--- a/internal/alerter/alerter.go
+++ b/internal/alerter/alerter.go
@@ -1,0 +1,144 @@
+package alerter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/stuttgart-things/homerun2-scout/internal/models"
+)
+
+// ThresholdConfig defines alerting thresholds.
+type ThresholdConfig struct {
+	ErrorThreshold    int64         // Alert when error count exceeds this
+	CriticalThreshold int64         // Alert when critical count exceeds this
+	Cooldown          time.Duration // Minimum time between alerts for the same metric
+}
+
+// Alerter checks aggregation results against thresholds and sends meta-alerts.
+type Alerter struct {
+	pitcherURL string
+	authToken  string
+	thresholds ThresholdConfig
+	httpClient *http.Client
+
+	mu          sync.Mutex
+	lastAlerted map[string]time.Time
+}
+
+// PitchRequest is the payload sent to omni-pitcher.
+type PitchRequest struct {
+	Title    string `json:"title"`
+	Message  string `json:"message"`
+	Severity string `json:"severity"`
+	Author   string `json:"author"`
+	System   string `json:"system"`
+	Tags     string `json:"tags"`
+}
+
+// New creates a new Alerter.
+func New(pitcherURL, authToken string, thresholds ThresholdConfig) *Alerter {
+	return &Alerter{
+		pitcherURL:  pitcherURL,
+		authToken:   authToken,
+		thresholds:  thresholds,
+		httpClient:  &http.Client{Timeout: 10 * time.Second},
+		lastAlerted: make(map[string]time.Time),
+	}
+}
+
+// Check evaluates the latest aggregation results against thresholds.
+func (a *Alerter) Check(ctx context.Context, summary *models.Summary, alerts *models.AlertStats) {
+	if a.pitcherURL == "" {
+		return
+	}
+
+	// Check error threshold
+	if errorCount, ok := summary.SeverityCounts["error"]; ok && a.thresholds.ErrorThreshold > 0 {
+		if errorCount >= a.thresholds.ErrorThreshold {
+			a.sendAlert(ctx, "error-threshold", PitchRequest{
+				Title:    "Scout: Error threshold exceeded",
+				Message:  fmt.Sprintf("Error count %d exceeds threshold %d", errorCount, a.thresholds.ErrorThreshold),
+				Severity: "warning",
+				Author:   "homerun2-scout",
+				System:   "homerun2-scout",
+				Tags:     "scout,threshold,error",
+			})
+		}
+	}
+
+	// Check critical threshold
+	if criticalCount, ok := summary.SeverityCounts["critical"]; ok && a.thresholds.CriticalThreshold > 0 {
+		if criticalCount >= a.thresholds.CriticalThreshold {
+			a.sendAlert(ctx, "critical-threshold", PitchRequest{
+				Title:    "Scout: Critical threshold exceeded",
+				Message:  fmt.Sprintf("Critical count %d exceeds threshold %d", criticalCount, a.thresholds.CriticalThreshold),
+				Severity: "critical",
+				Author:   "homerun2-scout",
+				System:   "homerun2-scout",
+				Tags:     "scout,threshold,critical",
+			})
+		}
+	}
+
+	// Check total alerts spike
+	if alerts.TotalAlerts > 0 && a.thresholds.ErrorThreshold > 0 {
+		totalThreshold := a.thresholds.ErrorThreshold + a.thresholds.CriticalThreshold
+		if totalThreshold > 0 && alerts.TotalAlerts >= totalThreshold {
+			a.sendAlert(ctx, "total-alerts-threshold", PitchRequest{
+				Title:    "Scout: Total alerts threshold exceeded",
+				Message:  fmt.Sprintf("Total alerts %d exceeds combined threshold %d", alerts.TotalAlerts, totalThreshold),
+				Severity: "error",
+				Author:   "homerun2-scout",
+				System:   "homerun2-scout",
+				Tags:     "scout,threshold,alerts",
+			})
+		}
+	}
+}
+
+func (a *Alerter) sendAlert(ctx context.Context, key string, req PitchRequest) {
+	a.mu.Lock()
+	if last, ok := a.lastAlerted[key]; ok && time.Since(last) < a.thresholds.Cooldown {
+		a.mu.Unlock()
+		slog.Debug("alert suppressed (cooldown)", "key", key)
+		return
+	}
+	a.lastAlerted[key] = time.Now()
+	a.mu.Unlock()
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		slog.Error("failed to marshal alert", "error", err)
+		return
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.pitcherURL+"/pitch", bytes.NewReader(body))
+	if err != nil {
+		slog.Error("failed to create alert request", "error", err)
+		return
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if a.authToken != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+a.authToken)
+	}
+
+	resp, err := a.httpClient.Do(httpReq)
+	if err != nil {
+		slog.Error("failed to send alert to pitcher", "key", key, "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		slog.Warn("alert pitch returned non-success", "key", key, "status", resp.StatusCode)
+		return
+	}
+
+	slog.Info("meta-alert sent to pitcher", "key", key, "title", req.Title)
+}

--- a/internal/alerter/alerter_test.go
+++ b/internal/alerter/alerter_test.go
@@ -1,0 +1,108 @@
+package alerter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stuttgart-things/homerun2-scout/internal/models"
+)
+
+func TestCheck_ErrorThresholdExceeded(t *testing.T) {
+	var received atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		var req PitchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode error: %v", err)
+		}
+		if req.Severity != "warning" {
+			t.Errorf("severity = %q, want %q", req.Severity, "warning")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	a := New(server.URL, "test-token", ThresholdConfig{
+		ErrorThreshold: 10,
+		Cooldown:       time.Second,
+	})
+
+	summary := &models.Summary{
+		SeverityCounts: map[string]int64{"error": 15},
+	}
+	alerts := &models.AlertStats{}
+
+	a.Check(context.Background(), summary, alerts)
+
+	if received.Load() != 1 {
+		t.Errorf("expected 1 alert sent, got %d", received.Load())
+	}
+}
+
+func TestCheck_BelowThreshold(t *testing.T) {
+	var received atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	a := New(server.URL, "", ThresholdConfig{
+		ErrorThreshold:    100,
+		CriticalThreshold: 10,
+		Cooldown:          time.Second,
+	})
+
+	summary := &models.Summary{
+		SeverityCounts: map[string]int64{"error": 5, "critical": 1},
+	}
+	alerts := &models.AlertStats{TotalAlerts: 6}
+
+	a.Check(context.Background(), summary, alerts)
+
+	if received.Load() != 0 {
+		t.Errorf("expected 0 alerts sent, got %d", received.Load())
+	}
+}
+
+func TestCheck_CooldownSuppression(t *testing.T) {
+	var received atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	a := New(server.URL, "", ThresholdConfig{
+		ErrorThreshold: 5,
+		Cooldown:       time.Hour, // Long cooldown
+	})
+
+	summary := &models.Summary{
+		SeverityCounts: map[string]int64{"error": 10},
+	}
+	alerts := &models.AlertStats{}
+
+	// First call sends
+	a.Check(context.Background(), summary, alerts)
+	// Second call suppressed by cooldown
+	a.Check(context.Background(), summary, alerts)
+
+	if received.Load() != 1 {
+		t.Errorf("expected 1 alert (2nd suppressed by cooldown), got %d", received.Load())
+	}
+}
+
+func TestCheck_NoPitcherURL(t *testing.T) {
+	a := New("", "", ThresholdConfig{ErrorThreshold: 1})
+	summary := &models.Summary{
+		SeverityCounts: map[string]int64{"error": 100},
+	}
+	// Should not panic
+	a.Check(context.Background(), summary, &models.AlertStats{})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,22 +4,28 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 )
 
 // Config holds the application configuration loaded from environment variables.
 type Config struct {
-	RedisAddr        string
-	RedisPort        string
-	RedisPassword    string
-	RedisearchIndex  string
-	ScoutInterval    time.Duration
-	RetentionTTL     time.Duration
-	RetentionEnabled bool
-	AuthToken        string
-	Port             string
-	LogFormat        string
-	LogLevel         string
+	RedisAddr              string
+	RedisPort              string
+	RedisPassword          string
+	RedisearchIndex        string
+	ScoutInterval          time.Duration
+	RetentionTTL           time.Duration
+	RetentionEnabled       bool
+	AuthToken              string
+	Port                   string
+	LogFormat              string
+	LogLevel               string
+	AlertPitcherURL        string
+	AlertPitcherToken      string
+	AlertErrorThreshold    int64
+	AlertCriticalThreshold int64
+	AlertCooldown          time.Duration
 }
 
 // LoadConfig reads configuration from environment variables with sensible defaults.
@@ -51,6 +57,32 @@ func LoadConfig() (*Config, error) {
 		cfg.RetentionTTL = ttl
 		cfg.RetentionEnabled = true
 	}
+
+	cfg.AlertPitcherURL = getEnv("ALERT_PITCHER_URL", "")
+	cfg.AlertPitcherToken = getEnv("ALERT_PITCHER_TOKEN", "")
+
+	if v := getEnv("ALERT_ERROR_THRESHOLD", ""); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ALERT_ERROR_THRESHOLD %q: %w", v, err)
+		}
+		cfg.AlertErrorThreshold = n
+	}
+
+	if v := getEnv("ALERT_CRITICAL_THRESHOLD", ""); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ALERT_CRITICAL_THRESHOLD %q: %w", v, err)
+		}
+		cfg.AlertCriticalThreshold = n
+	}
+
+	cooldownStr := getEnv("ALERT_COOLDOWN", "5m")
+	cooldown, err := time.ParseDuration(cooldownStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid ALERT_COOLDOWN %q: %w", cooldownStr, err)
+	}
+	cfg.AlertCooldown = cooldown
 
 	return cfg, nil
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/redis/go-redis/v9"
 	"github.com/stuttgart-things/homerun2-scout/internal/aggregator"
+	"github.com/stuttgart-things/homerun2-scout/internal/alerter"
 	"github.com/stuttgart-things/homerun2-scout/internal/banner"
 	"github.com/stuttgart-things/homerun2-scout/internal/config"
 	"github.com/stuttgart-things/homerun2-scout/internal/handlers"
@@ -57,6 +58,18 @@ func main() {
 
 	// Start aggregator
 	agg := aggregator.New(rdb, cfg.RedisearchIndex, cfg.ScoutInterval)
+
+	// Setup threshold alerter (if configured)
+	if cfg.AlertPitcherURL != "" {
+		a := alerter.New(cfg.AlertPitcherURL, cfg.AlertPitcherToken, alerter.ThresholdConfig{
+			ErrorThreshold:    cfg.AlertErrorThreshold,
+			CriticalThreshold: cfg.AlertCriticalThreshold,
+			Cooldown:          cfg.AlertCooldown,
+		})
+		agg.SetOnCycleCallback(a.Check)
+		slog.Info("threshold alerting enabled", "pitcherURL", cfg.AlertPitcherURL)
+	}
+
 	agg.Start(ctx)
 
 	// Start retention cleaner (if enabled)


### PR DESCRIPTION
## Summary
- Adds `internal/alerter/` package that checks aggregation results against thresholds
- Sends meta-alerts to omni-pitcher via `POST /pitch` when thresholds are exceeded
- Configurable: `ALERT_PITCHER_URL`, `ALERT_PITCHER_TOKEN`, `ALERT_ERROR_THRESHOLD`, `ALERT_CRITICAL_THRESHOLD`, `ALERT_COOLDOWN`
- Cooldown deduplication prevents alert storms
- Disabled by default; set `ALERT_PITCHER_URL` to enable
- Aggregator callback pattern for clean integration

## Test plan
- [ ] `go test ./...` passes
- [ ] Alerter sends when threshold exceeded (unit test with mock HTTP)
- [ ] Alerter suppresses duplicate alerts within cooldown
- [ ] No alerts sent when below threshold

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)