### PR TITLE
ci(preview): add PR-preview workflow set

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -14,7 +14,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-pr:
+    if: github.event_name == 'pull_request'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      registry: ghcr.io
+      tags: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }},pr-${{ github.event.number }}
+    secrets: inherit # pragma: allowlist secret
+
+  build-main:
+    if: github.event_name != 'pull_request'
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest

--- a/.github/workflows/cleanup-pr-artifacts.yaml
+++ b/.github/workflows/cleanup-pr-artifacts.yaml
@@ -1,0 +1,16 @@
+---
+name: Cleanup PR Artifacts
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  cleanup:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-cleanup-pr-artifacts.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      packages: homerun2-scout,homerun2-scout-kustomize
+      dry-run: false
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/comment-preview-url.yaml
+++ b/.github/workflows/comment-preview-url.yaml
@@ -1,0 +1,16 @@
+---
+name: Comment Preview URL on PR
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - main
+
+jobs:
+  comment:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-comment-preview-url.yaml@main
+    with:
+      hostname-prefix: scout-pr
+      hostname-domain: homerun2-dev.sthings-vsphere.labul.sva.de
+      namespace-prefix: homerun2-scout-pr
+    secrets: inherit # pragma: allowlist secret

--- a/.github/workflows/push-kustomize-pr.yaml
+++ b/.github/workflows/push-kustomize-pr.yaml
@@ -1,0 +1,21 @@
+---
+name: Push PR Kustomize OCI
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  push-kustomize:
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-push-kustomize.yaml@main
+    with:
+      runs-on: ubuntu-latest
+      kcl-source-dir: kcl
+      kcl-profile-file: tests/kcl-deploy-profile.yaml
+      kustomize-oci-repo: ghcr.io/stuttgart-things/homerun2-scout-kustomize
+      tag: pr-${{ github.event.number }}-${{ github.event.pull_request.head.sha }}
+    secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Mirrors the workflow set shipped by `homerun2-omni-pitcher` (pilot) and `homerun2-core-catcher` (first transplant) for per-PR preview environments. Same reusable callers, same artifact tag scheme (`pr-<num>-<sha>`), same bot-comment pattern — now via the freshly-extracted reusable bot workflow [`call-comment-preview-url.yaml`](https://github.com/stuttgart-things/github-workflow-templates/blob/main/.github/workflows/call-comment-preview-url.yaml).

| Workflow | Purpose |
|---|---|
| `build-scan-image.yaml` | adds `build-pr` job pushing to `ghcr.io/stuttgart-things/homerun2-scout:pr-<num>-<sha>` (+ moving `pr-<num>` tag) on PR push; `build-main` job for `push: main` unchanged |
| `push-kustomize-pr.yaml` | pushes the matching kustomize OCI artifact to `ghcr.io/stuttgart-things/homerun2-scout-kustomize:pr-<num>-<sha>` |
| `cleanup-pr-artifacts.yaml` | deletes both packages' `pr-<num>-*` versions on PR close (`dry-run: false`) |
| `comment-preview-url.yaml` | **thin caller** of the new reusable. Sticky bot comment with: URL `scout-pr-<num>.homerun2-dev.sthings-vsphere.labul.sva.de`, namespace `homerun2-scout-pr-<num>`, ArgoCD link |

## Per stuttgart-things/homerun2-omni-pitcher#116

Second component rollout after `core-catcher`. Decisions locked in:
- **Namespace**: `homerun2-scout-pr-<num>` (mirrors image name)
- **Hostname**: `scout-pr-<num>.homerun2-dev....`
- **Preview contents**: scout (SUT) + omni-pitcher + redis-stack (full chain so the dashboard renders against a populated Redis)

## Cluster-side wiring (separate PR on stuttgart-things)

After this lands, a stuttgart-things PR adds:

- `scout-pr-preview-appset.yaml` — AppSet with PR generator pointed at this repo
- 4 new policy Applications (`homerun2-scout-preview-{quota,secrets,seed-data,sweep}.yaml`) — same catalog charts as omni-pitcher's, deployed with `namespacePrefix: \"homerun2-scout-pr-*\"` and Secret names adjusted

## Test plan

- [x] Workflows YAML-valid
- [x] Artifact paths point at `homerun2-scout` (image) + `homerun2-scout-kustomize` (kustomize OCI)
- [x] Bot caller inputs match the AppSet's planned hostname/namespace shape
- [ ] After merge + cluster-side PR: open a no-op PR on this repo → bot comments → CI publishes artifacts → AppSet picks up → preview env spins up