### PR TITLE
feat: ship HTTPRoute in the kustomize OCI base (Option B for argocd#116)

### DIFF
--- a/tests/kcl-deploy-profile.yaml
+++ b/tests/kcl-deploy-profile.yaml
@@ -6,6 +6,15 @@ config.ingressHost: homerun2-scout.example.com
 config.ingressTlsEnabled: true
 config.ingressAnnotations:
   cert-manager.io/cluster-issuer: cluster-issuer-approle
+# HTTPRoute lives in the same kustomize apply as the Service so they land
+# atomically — avoids the Cilium gateway controller caching BackendNotFound
+# when the HTTPRoute is created before its Service (stuttgart-things/argocd#116).
+# Consumers without a Gateway API can drop the HTTPRoute via a kustomize delete
+# patch; the homerun2-install chart patches the parentRef + hostname per env.
+config.httpRouteEnabled: true
+config.httpRouteParentRefName: homerun2-dev-gateway
+config.httpRouteParentRefNamespace: default
+config.httpRouteHostname: homerun2-scout.example.com
 config.redisAddr: redis-stack.homerun2.svc.cluster.local
 config.redisPort: "6379"
 config.redisearchIndex: messages


### PR DESCRIPTION
## Summary

Flip `config.httpRouteEnabled` to `true` in the default KCL deploy profile so the scout kustomize OCI carries the HTTPRoute alongside the Service. KCL is already conditional on the flag (`kcl/httproute.k`); this just enables it.

**Why** — stuttgart-things/argocd#116: the per-PR preview env races Cilium's gateway controller when the HTTPRoute is created by one ArgoCD Application before the Service is created by another. Cilium stamps `BackendNotFound` and never re-resolves. Shipping HTTPRoute + Service in the same kustomize apply eliminates the cross-Application race architecturally.

This is **Option B** from the issue — same shape as the merged stuttgart-things/homerun2-omni-pitcher#125 / stuttgart-things/homerun2-core-catcher#63 (single-block change in the deploy profile).

## Default values

The profile bakes placeholders for the dev cluster (`homerun2-dev-gateway` in `default` ns, hostname `homerun2-scout.example.com`). The install chart patches all three per env (companion PR on stuttgart-things/argocd adding `scout.inlineHttpRoute`).

Consumers without a Gateway API drop the HTTPRoute via a kustomize delete patch (same pattern the chart already uses for the rendered Ingress).

## Test plan

- [x] Local `kcl run -D config.httpRouteEnabled=true …` emits the HTTPRoute alongside Service + Deployment + ConfigMap + Secret + ServiceAccount + RBAC.
- [ ] Preview env (with `preview` label) after the argocd companion PR + AppSet flip merge: `homerun2-pr-<num>-scout` Synced/Healthy on first reconcile; HTTPRoute reaches `ResolvedRefs: True` without `kubectl annotate reconcile-bump=…`.

## Follow-up (separate PR)

The KCL doesn't yet render admission-webhook defaults on `parentRefs.{group,kind}` / `backendRefs.{group,kind,weight}` — mirrored on omni-pitcher in stuttgart-things/homerun2-omni-pitcher#127. The chart-side JSON-Patch covers `parentRefs` drift; `backendRefs` may flag OutOfSync until the same KCL fix lands here. Not blocking acceptance (Cilium resolution is independent of the drift).

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)