### PR TITLE
chore(deps): bundle 3 Renovate dagger dep bumps

### DIFF
--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -3,7 +3,7 @@ module dagger/dagger
 go 1.26.0
 
 require (
-	dagger.io/dagger v0.19.11
+	dagger.io/dagger v0.20.8
 	github.com/Khan/genqlient v0.8.1
 	github.com/vektah/gqlparser/v2 v2.5.30
 	go.opentelemetry.io/otel v1.38.0

--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -5,7 +5,7 @@ go 1.26.0
 require (
 	dagger.io/dagger v0.20.8
 	github.com/Khan/genqlient v0.8.1
-	github.com/vektah/gqlparser/v2 v2.5.30
+	github.com/vektah/gqlparser/v2 v2.5.33
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
 )

--- a/dagger/go.mod
+++ b/dagger/go.mod
@@ -6,8 +6,8 @@ require (
 	dagger.io/dagger v0.20.8
 	github.com/Khan/genqlient v0.8.1
 	github.com/vektah/gqlparser/v2 v2.5.33
-	go.opentelemetry.io/otel v1.38.0
-	go.opentelemetry.io/otel/trace v1.38.0
+	go.opentelemetry.io/otel v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 )
 
 require (
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/log v0.14.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.38.0
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.14.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.8.0 // indirect
@@ -42,10 +42,10 @@ require (
 	google.golang.org/protobuf v1.36.9 // indirect
 )
 
-replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.14.0
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.19.0
 
-replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.14.0
+replace go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.19.0
 
-replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.14.0
+replace go.opentelemetry.io/otel/log => go.opentelemetry.io/otel/log v0.19.0
 
-replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.14.0
+replace go.opentelemetry.io/otel/sdk/log => go.opentelemetry.io/otel/sdk/log v0.19.0


### PR DESCRIPTION
Combines the three dagger/go.mod Renovate PRs into one branch for a single preview-env smoke run. Each commit preserved (cherry-picked) so attribution stays with renovate-bot.

## Included

| PR | Module | From → To | Where |
|----|--------|-----------|-------|
| #26 | `dagger.io/dagger` | v0.19.11 → v0.20.8 | `dagger/go.mod` |
| #22 | `github.com/vektah/gqlparser/v2` | v2.5.30 → v2.5.33 | `dagger/go.mod` |
| #27 | opentelemetry-go monorepo | otel v1.38.0 → v1.43.0 (+ log v0.14.0 → v0.19.0) | `dagger/go.mod` |

## Excluded

- **#48** (kubernetes monorepo → v0.36.1) bumps root `go.mod` to `go 1.26.0`. The centrally-managed reusable workflow `stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml` pins `GOTOOLCHAIN=local` on Go 1.25.5, so the build fails with `go: go.mod requires go >= 1.26.0`. Resolution path: bump Go in the central template first, then close #48 by merging this bundle (or re-bundling).

## Conflict resolution

All three PRs touch the same `require (...)` block in `dagger/go.mod`. Resolved as the union: vektah `v2.5.33` (from #22) + otel `v1.43.0` (from #27) + dagger.io/dagger `v0.20.8` (from #26).

## Skipping go mod tidy

Per the established pattern, `go mod tidy` is **not** run on `dagger/go.mod` — `dagger/main.go` imports `dagger/dagger/internal/dagger`, which is generated by `dagger develop` and gitignored. Running tidy in a fresh env strips every `require` because the imports look unresolved. Hand-edited version lines only.

Expect `renovate/artifacts` red on this PR for the same reason it's red on every Renovate PR touching `dagger/go.mod` in homerun2-* repos. Real CI (build, build-and-test, lint) stays green.

## Test plan

- [x] `go build ./...` green on root module
- [x] `go test ./...` green on root module
- [ ] build-pr image + push-kustomize-pr workflows green
- [ ] preview env `homerun2-scout-pr-58` Synced/Healthy
- [ ] `curl https://scout-pr-58.homerun2-dev.…/health` returns 200

Closes #22, #26, #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)