### PR TITLE
chore(deps): bump dagger module goVersion default to 1.26.0

### DIFF
--- a/dagger/main.go
+++ b/dagger/main.go
@@ -36,7 +36,7 @@ func (m *Dagger) Build(
 	// +default=""
 	ldflags string,
 	// +optional
-	// +default="1.25.4"
+	// +default="1.26.0"
 	goVersion string,
 	// +optional
 	// +default="linux"
@@ -90,7 +90,7 @@ func (m *Dagger) BuildAndTestBinary(
 	ctx context.Context,
 	source *dagger.Directory,
 	// +optional
-	// +default="1.25.4"
+	// +default="1.26.0"
 	goVersion string,
 	// +optional
 	// +default="linux"


### PR DESCRIPTION
## Summary

Bumps the Dagger module's `goVersion` default from `1.25.4` → `1.26.0` on both `BuildBinary` (line 39) and `BuildAndTestBinary` (line 93) in `dagger/main.go`.

## Why

Pair to stuttgart-things/github-workflow-templates#89, which bumped the central `call-ko-build` / `call-go-release` defaults — that one fixed the `build-pr` job. This one fixes the `build-and-test` job, which calls Dagger directly and gets the goVersion from this module's default rather than from the workflows-templates input.

Renovate's kubernetes-monorepo bump on #59 currently fails `build-and-test` with:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.4; GOTOOLCHAIN=local)
```

Once this lands, #59 can re-run and go green end-to-end.

## Test plan

- [x] Diff is two `// +default="1.25.4"` → `// +default="1.26.0"` lines, no functional Go changes.
- [ ] After merge: re-run CI on #59 → `build-and-test` passes alongside the already-fixed `build-pr`.

## Note

Same one-line bump pending across the other homerun2-* repos with Dagger modules (omni-pitcher, core-catcher, etc.) when their kubernetes-monorepo Renovate PRs land. Each repo's `dagger/main.go` needs the analogous edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)